### PR TITLE
[Patch] Improvements on "exports", "layouts" and consent responsivness

### DIFF
--- a/src/app/survey/[slug]/[step]/_components/ParticipationConsent.tsx
+++ b/src/app/survey/[slug]/[step]/_components/ParticipationConsent.tsx
@@ -7,8 +7,8 @@ import { NL } from "@/static/participation.js"
 import { useSurveyQuery } from "@/api/graphql/queries/survey.gql.generated.js"
 import { client } from "@/api/gql-client.js"
 import { useCreateParticipationMutation } from "@/api/graphql/queries/participation.gql.generated.js"
-import { useMediaQueries } from "@/utils/hooks/mediaqueries.js"
 import PDFPreview from "@/components/PDFPreview"
+import { cn } from "@/utils/ui"
 
 // ---- TYPES
 
@@ -38,48 +38,45 @@ export default function ParticipationConsent({ surveyId, onConsent, onRefuse }: 
 
   const attributes = survey?.survey?.data?.attributes
   const url = attributes?.notice_consent?.data?.attributes?.url
-  const { isTablet } = useMediaQueries()
 
   if (isLoading) return <Box mt="20">Please wait...</Box>
 
   return (
     <Box
-      display="flex"
-      justifyContent="space-around"
-      w="100%"
-      overflow="hidden"
-      h="100%"
-      flexDirection={isTablet ? "column" : "row"}
+      className="flex flex-col lg:flex-row justify-around w-full h-full min-h-0 overflow-auto"
     >
-      <Box
-        className="p-2 bg-gray-100"
-        h="100vh"
-        pb={isTablet ? "50px" : "0px"}
-        w={isTablet ? "90%" : "100%"}
-      >
+      <Box className="flex flex-col p-2 bg-gray-100 flex-grow min-h-[500px] h-full w-full">
         { url
           ? <PDFPreview url={url} />
           : <Box w="100%" h="100%" backgroundColor="gray.100" />
         }
       </Box>
 
-      <Container variant="rightPart" className={isTablet ? "background__grid" : ""}>
-        <Center h={isTablet ? "unset" : "100vh"} w={isTablet ? "100%" : "unset"}>
-          <Box display="flex" flexDir="column" w={isTablet ? "90%" : "50%"}>
-            <div className="mb-16">
-              <span className="font-light text-gray-500">Notice pour</span><br />
-              <span className="font-semibold text-2xl">{ attributes?.title }</span>
-            </div>
+      <Container className={cn (
+        'flex shrink-0 justify-center h-auto overflow-hidden',
+        'lg:shrink lg:h-full lg:overflow-auto lg:w-full lg:max-w-[53%] lg:border-l lg:border-[rgb(234, 234, 239)]',
+      )}>
+        <Box className='flex flex-col self-center w-full xl:w-2/3 p-4 lg:p-0'>
+          <div className="w-full">
+            <span className="font-light text-gray-500">Notice pour<span className="lg:hidden"> : </span></span>
+            <br className="max-lg:hidden" />
+            <span className="font-semibold text-2xl">{ attributes?.title }</span>
+          </div>
 
-            <Button className="w-full" mb="20px" variant="rounded" onClick={onAccept} mr="10">
+          <div className={cn(
+              "flex mt-4 flex-row-reverse",
+              "lg:mt-16 lg:flex-col lg:space-y-5",
+            )}
+          >
+            <Button className="w-full" variant="rounded" whiteSpace="normal" onClick={onAccept}>
               {NL.button.consent.accept}
             </Button>
 
             <Button className="w-full" variant="rounded" onClick={onDecline}>
               {NL.button.consent.refuse}
             </Button>
-          </Box>
-        </Center>
+          </div>
+        </Box>
       </Container>
     </Box>
   )

--- a/src/app/survey/[slug]/[step]/_components/ParticipationForm.tsx
+++ b/src/app/survey/[slug]/[step]/_components/ParticipationForm.tsx
@@ -264,15 +264,16 @@ function ParticipationSaved() {
         p={isTablet ? "30px 20px" : "50px"}
         border="1px solid"
         borderColor="brand.line"
-        w={isTablet ? "90%" : "480px"}
+        w={isTablet ? "90%" : "600px"}
       >
         <Text variant="xl" mb="20px">
           🎉
         </Text>
-        <Text>Votre participation à bien été enregistrée, merci beaucoup !</Text>
-        <Button mt="50px" variant="roundedBlue" minW="200px" onClick={() => router.push("/")}>
-          Revenir au portail
-        </Button>
+
+        <Text>
+          Votre participation à bien été enregistrée.<br/>
+          Merci beaucoup !
+        </Text>
       </Box>
     </Center>
   )

--- a/src/app/survey/[slug]/[step]/page.tsx
+++ b/src/app/survey/[slug]/[step]/page.tsx
@@ -13,6 +13,7 @@ import { useConsentHandlers } from "@/utils/participations/consent-handler.js"
 import Loader from "@/components/Spinner/index.tsx"
 import ParticipationConsent from "./_components/ParticipationConsent.tsx"
 import ParticipationForm from "./_components/ParticipationForm.tsx"
+import { useMediaQueries } from "@/utils/hooks/mediaqueries.ts";
 
 // ---- TYPES
 
@@ -45,7 +46,7 @@ export default function Participation({ params }: Props): JSX.Element {
 
   // If there is already a completed participation in local storage
   if (participation?.completed) {
-    return <OverWarning msg={NL.msg.thxParticipation} cta={NL.button.backToWelcome} action={goBackHome} />;
+    return <OverWarning msg={NL.msg.thxParticipation} cta={NL.button.backToWelcome} action={goBackHome} />
   }
 
   // LOADING STATE
@@ -101,15 +102,19 @@ type OverWarningProps = {
 };
 
 const OverWarning = ({ msg, cta, action }: OverWarningProps) => {
+  const { isTablet } = useMediaQueries()
+  
   return (
-    <Center h="100vh">
-      <Flex flexDir="column">
+    <Center h="100vh" display="flex" flexDirection="column" backgroundColor="gray.100">
+      <Box
+        backgroundColor="white"
+        p={isTablet ? "30px 20px" : "50px"}
+        border="1px solid"
+        borderColor="brand.line"
+        w={isTablet ? "90%" : "600px"}
+      >
         <Text variant="title">{msg}</Text>
-
-        <Button mt="40px" variant="roundedBlue" onClick={action}>
-          {cta}
-        </Button>
-      </Flex>
+      </Box>
     </Center>
-  );
-};
+  )
+}

--- a/src/app/survey/[slug]/[step]/page.tsx
+++ b/src/app/survey/[slug]/[step]/page.tsx
@@ -68,7 +68,7 @@ export default function Participation({ params }: Props): JSX.Element {
   }
 
   if (!surveyId) {
-    return <p>Une erreur est survenue</p>;
+    return <p>Une erreur est survenue</p>
   }
 
   // CONSENT
@@ -90,8 +90,8 @@ export default function Participation({ params }: Props): JSX.Element {
     />
   }
 
-  return <Box mt="60">Something went wrong...</Box>;
-};
+  return <Box mt="60">Something went wrong...</Box>
+}
 
 // ---- SUB COMPONENTS
 

--- a/src/components/CreateSurvey/CreateLanding/Preview/index.tsx
+++ b/src/components/CreateSurvey/CreateLanding/Preview/index.tsx
@@ -70,7 +70,13 @@ export default function Preview({ isUserView, data, author, needConsent, surveyI
   const hasImage = Boolean(coverSrc)
   const hasMedia = hasVideo || hasImage
   const hasMembers = Boolean(data?.attributes?.members?.length > 0)
-  const hasAboutPage = Boolean(data?.attributes?.about)
+  const hasAboutPage = useMemo(() => {
+    if (!Boolean(data?.attributes?.about)) return false
+    // Check if there is only one paragraph and if it's empty (and reverse the boolean result)
+    if (data?.attributes.about.length === 1) {
+      return !(data?.attributes.about[0]?.children?.length === 1 && data?.attributes.about[0]?.children[0]?.text === "")
+    }
+  }, [data?.attributes?.about])
   const isInactive = !isUserView || loading
 
   // Callback for participate button

--- a/src/components/CreateSurvey/CreateLanding/Preview/index.tsx
+++ b/src/components/CreateSurvey/CreateLanding/Preview/index.tsx
@@ -135,7 +135,7 @@ export default function Preview({ isUserView, data, author, needConsent, surveyI
         textAlign="left"
         px="5%"
       >
-        <Text variant="xxl" fontWeight="bold" color="white" ml="-2px" wordBreak="break-word">
+        <Text variant="xxl" fontWeight="bold" color="white" ml="-2px">
           {attributes?.title}
         </Text>
 

--- a/src/components/Fields/Checkbox.tsx
+++ b/src/components/Fields/Checkbox.tsx
@@ -25,7 +25,7 @@ export default function CustomCheckbox({ label, helpText, checkbox, isRequired, 
               {checkbox && (
                 checkbox.map(({ value, label }) => {
                   return (
-                    <CheckboxControl key={value} name={id} value={value} isRequired={isRequired} m={2} maxW="100%" overflow="hidden">
+                    <CheckboxControl display={'flex'} w={'100%'} key={value} name={id} value={value} isRequired={isRequired} m={2} overflow="hidden">
                       {label}
                     </CheckboxControl>
                   );

--- a/src/components/Fields/MonoThumbnail.tsx
+++ b/src/components/Fields/MonoThumbnail.tsx
@@ -205,7 +205,7 @@ function AssociatedQuestion({
   }
 
   useEffect(() => {
-    helpers.setValue(mono?.value?.[step]?.value)
+    helpers.setValue(mono?.value?.[step]?.value ?? associatedInput.attributes.min)
   // We update the associated input value ONLY when the step or the input itself changes
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [associatedInput, step])

--- a/src/components/Fields/Radiobox.tsx
+++ b/src/components/Fields/Radiobox.tsx
@@ -30,7 +30,7 @@ export default function CustomRadioBox({ label, helpText, radios, id, m, p, isRe
                   {radios ? (
                     radios.map(({ value, label }) => {
                       return (
-                        <Radio value={value} id={id} key={value} isRequired={isRequired} m={2}>
+                        <Radio display={'flex'} w={'100%'} value={value} id={id} key={value} isRequired={isRequired} m={2}>
                           {label}
                         </Radio>
                       );

--- a/src/components/Fields/Slider.tsx
+++ b/src/components/Fields/Slider.tsx
@@ -43,10 +43,10 @@ export default function CustomSlider({
   const [field, , helpers] = useField(id);
 
   useEffect(() => {
-    if (defaultValue) {
-      helpers.setValue(defaultValue);
+    if (!field.value) {
+      helpers.setValue(defaultValue ?? min)
     }
-  }, [defaultValue, helpers]);
+  }, [defaultValue, field.value, helpers, min])
 
   const cleanValue = useCallback((value: string | number | undefined | null, defaultValue: number): number => {
     if (value === undefined || value === null || value === "") {

--- a/src/components/PDFPreview.tsx
+++ b/src/components/PDFPreview.tsx
@@ -6,7 +6,7 @@ import { Document, Page, pdfjs } from "react-pdf"
 import 'react-pdf/dist/Page/TextLayer.css'
 import 'react-pdf/dist/Page/AnnotationLayer.css'
 
-import { useMediaQueries } from "@/utils/hooks/mediaqueries.js"
+import { cn } from "@/utils/ui"
 
 // ---- STATICS
 
@@ -21,8 +21,6 @@ interface Props {
 // ---- COMPONENT
 
 export default function PDFPreview({ url }: Props): JSX.Element {
-  const { isTablet } = useMediaQueries()
-
   const [numPages, setNumPages] = useState(1)
   const [pageNumber, setPageNumber] = useState(1)
 
@@ -31,16 +29,15 @@ export default function PDFPreview({ url }: Props): JSX.Element {
   }, [])
 
   return (
-    <div className="flex flex-col h-full justify-center">
-      <Document className="overflow-auto border shadow-sm" file={url} onLoadSuccess={onDocumentLoadSuccess}>
-        <Page pageNumber={pageNumber} height={isTablet ? 400 : 900} />
+    <div className="flex flex-col h-full w-full max-w-fit justify-center self-center min-h-[500px]">
+      <Document className="overflow-auto w-full h-full self-center" file={url} onLoadSuccess={onDocumentLoadSuccess}>
+        <Page pageNumber={pageNumber} className={cn(
+          "m-auto w-fit h-full overflow-auto border shadow-sm",
+        )}/>
       </Document>
  
       <Flex
-        mt="10px"
-        mb="10px"
-        justifyContent="space-between"
-        alignItems="center"
+        className="mt-[10px] w-full justify-between items-center self-center"
       >
         {pageNumber !== 1 ? (
           <Button variant="rounded" backgroundColor="black" p="0" onClick={() => setPageNumber(pageNumber - 1)}>

--- a/src/static/participation.ts
+++ b/src/static/participation.ts
@@ -1,7 +1,7 @@
 export const NL = {
   msg: {
     nodata: "No data for this page",
-    thxParticipation: "👌 Merci d'avoir rempli cette enquête",
+    thxParticipation: "Merci d'avoir rempli cette enquête 👌",
     surveyOver:
       "Il n'est plus possible de participer à cette enquête ! Merci de votre interêt. Si vous pensez qu'il s'agit d'une erreur n'hésitez pas à contacter un administrateur.",
     missingConsent: "Vous n'avez pas encore consenti à participer. Redirection...",


### PR DESCRIPTION
## What
This PR improves the export behavior with sliders, changes the layout of checkboxes and radio inputs (+ other minor positions) and correct the responsiveness of the consent page (especially on mobile).

## How
- set the answer base value to min on input sliders
- put the options (in radio & checkboxes) in one column
- better detect when "a propos" is empty (to hide it)
- remove backlinks to the portal
- rework HTML/Css of the consent page to make it more responsive and at least usable in most cases