### PR TITLE
[Feat] Add `bulkSave` operation at the end of a participation

### DIFF
--- a/src/api/gql-client.ts
+++ b/src/api/gql-client.ts
@@ -17,7 +17,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      authorization: buildBearer(jwt),
+      authorization: buildBearer(jwt ?? process.env.STRAPI_API_TOKEN),
     }
   }
 })
@@ -38,7 +38,7 @@ export const apollo = new ApolloClient({
 export const client = new GraphQLClient(API_URL, {
   mode: "cors",
   headers: {
-    "Authorization": "",
+    "Authorization": `bearer ${ process.env.STRAPI_API_TOKEN }`,
   }
 });
 

--- a/src/api/gql-client.ts
+++ b/src/api/gql-client.ts
@@ -18,7 +18,7 @@ const authLink = setContext((_, { headers }) => {
   return {
     headers: {
       ...headers,
-      authorization: buildBearer(jwt ?? process.env.STRAPI_API_TOKEN),
+      authorization: buildBearer(jwt),
     }
   }
 })
@@ -39,7 +39,7 @@ export const apollo = new ApolloClient({
 export const client = new GraphQLClient(API_URL, {
   mode: "cors",
   headers: {
-    "Authorization": buildBearer(process.env.STRAPI_API_TOKEN),
+    "Authorization": "",
   }
 });
 

--- a/src/api/gql-client.ts
+++ b/src/api/gql-client.ts
@@ -13,6 +13,7 @@ const authLink = setContext((_, { headers }) => {
   // get the authentication token from local storage if it exists
   const storage = localStorage.getItem("process__user")
   const jwt = storage ? JSON.parse(storage).jwt : null
+
   // return the headers to the context so httpLink can read them
   return {
     headers: {
@@ -38,7 +39,7 @@ export const apollo = new ApolloClient({
 export const client = new GraphQLClient(API_URL, {
   mode: "cors",
   headers: {
-    "Authorization": `bearer ${ process.env.STRAPI_API_TOKEN }`,
+    "Authorization": buildBearer(process.env.STRAPI_API_TOKEN),
   }
 });
 

--- a/src/api/graphql/queries/answers.graphql
+++ b/src/api/graphql/queries/answers.graphql
@@ -9,3 +9,10 @@ mutation updateAnswer ($id: ID!, $data: AnswerInput!) {
     data { ...answerFragment }
   }
 }
+
+mutation bulkSaveAnswers ($data: [UpsertAnswerInput!]!) {
+  bulkSave(data: $data) {
+    data { ...answerFragment },
+    errors
+  }
+}

--- a/src/app/survey/[slug]/[step]/_components/ParticipationForm.tsx
+++ b/src/app/survey/[slug]/[step]/_components/ParticipationForm.tsx
@@ -7,6 +7,7 @@ import { captureMessage } from "@sentry/nextjs"
 
 import { useAppDispatch, useAppSelector } from "@/redux/hooks/index.js"
 import { actions } from "@/redux/slices/participation/status.js"
+import { actions as answersActions } from "@/redux/slices/participation/answers.ts"
 import { PageParticipationRedux, selectors } from "@/redux/slices/participation/page.js"
 import { selectors as scientistDataSelectors } from "@/redux/slices/scientistData.js"
 import { selectors as answerSelector } from "@/redux/slices/participation/answers.ts"
@@ -203,15 +204,17 @@ export default function ParticipationForm({ surveyId, participationId, mode }: P
 function useFinishHandler(participationId: string, slug: string) {
   const { mutateAsync: finishParticipationApi } = useFinishParticipationMutation(client)
   const { finishParticipation } = useLocalParticipation(slug)
+  const dispatch = useAppDispatch()
   const answers = useAppSelector(answerSelector.selectAll)
 
   const onFinish = useCallback(async () => {
     captureMessage("Participation finished", { level: 'debug', extra: { participationId, nbAnswers: answers.length, answers }})
+    dispatch(answersActions.bulkSave())
 
     // Tell the API we're done and wait for it to be saved
     await finishParticipationApi({ id: participationId, completedAt: new Date() })
     finishParticipation()
-  }, [finishParticipationApi, participationId, finishParticipation, answers])
+  }, [participationId, answers, dispatch, finishParticipationApi, finishParticipation])
 
   return {
     onFinish,

--- a/src/redux/epics/participation/answers.epic.ts
+++ b/src/redux/epics/participation/answers.epic.ts
@@ -1,15 +1,15 @@
 import { map, switchMap, filter, scan, debounceTime, timeInterval } from "rxjs"
 import { combineEpics, ofType } from "redux-observable"
 import { Epic } from "@/redux/store/index.js"
-import { captureException } from "@sentry/nextjs"
+import { captureException, captureMessage } from "@sentry/nextjs"
 
-import { actions, selectors, UpsertedAnswerPayload } from "@/redux/slices/participation/answers.js"
+import { actions, BulkSavedPayload, selectors, UpsertedAnswerPayload } from "@/redux/slices/participation/answers.js"
 import { sdk } from "@/api/gql-client.js"
 import { CreateAnswerMutation, UpdateAnswerMutation } from "@/api/graphql/sdk.generated.js"
 
 const DEBOUNCE_TIME = 3000
 
-// Initialize pages-visited upon init
+// Update answers in the backend
 const upsertAnswersEpic: Epic = (action$, state$) =>
   action$.pipe(
     ofType(actions.update.type),
@@ -33,7 +33,7 @@ const upsertAnswersEpic: Epic = (action$, state$) =>
 
       const participationId = state$.value.participation.status.participationId
       if (!participationId) {
-        captureException(new Error("Missing participation ID to save answers !"))
+        captureException(new Error("Upsert answer : Missing participation ID to save answers !"))
         return []
       }
 
@@ -69,7 +69,6 @@ const upsertAnswersEpic: Epic = (action$, state$) =>
           }
 
           const value = res.value
-
           let target
           let rawAnswer
 
@@ -87,7 +86,10 @@ const upsertAnswersEpic: Epic = (action$, state$) =>
 
           // Sanitize into correct payload form then push into related target
           const qId = rawAnswer.attributes?.question?.data?.id
-          if (!qId) return acc
+          if (!qId) {
+            captureException(new Error('Upsert answer : no question ID detected in resulting promise'), { extra: { rawAnswer } })
+            return acc
+          }
 
           const answer = { id: qId, changes: { id: rawAnswer.id } }
           target.push(answer)
@@ -101,4 +103,80 @@ const upsertAnswersEpic: Epic = (action$, state$) =>
     })
   )
 
-export const answersEpics = combineEpics(upsertAnswersEpic)
+// Bulk update of the whole participation (this is a safeguard)
+const bulkSaveAnswersEpic: Epic = (action$, state$) =>
+    action$.pipe(
+      ofType(actions.bulkSave.type),
+      switchMap(async () => {
+        const mode = state$.value.participation.status.mode
+        if (mode === "preview") return []
+
+        const participationId = state$.value.participation.status.participationId
+        if (!participationId) {
+          captureException(new Error("Bulk save : Missing participation ID to save answers !"))
+          return []
+        }
+
+        const answers = selectors.selectAll(state$.value)
+        const sanitizeAnswers = answers.map((a) => {
+          let { id, questionId, value } = a
+
+          // Wrap string so it doesn't crash in the backend (STRAPI, JSON, toussa)
+          if (typeof value === "string") {
+            value = { answer: value }
+          }
+
+          return { id, question: questionId, participation: participationId, value }
+        })
+
+        // Create or update, depending on the presence of an Answer ID
+        try {
+          const res = await sdk.bulkSaveAnswers({ data: sanitizeAnswers })
+
+          // Catch errors if any
+          if (res.bulkSave?.errors.length > 0) {
+            captureException(new Error('Bulk save : some answers were not saved'), { extra: { participationId, errors: res.bulkSave?.errors } })
+          }
+
+          // Then check for data to continue the pipeline
+          if (!res.bulkSave?.data) {
+            captureException(new Error('Bulk save : no data detected in resulting promise'), { extra: { participationId, res } })
+            return []
+          }
+
+          captureMessage('Bulk save : answers saved', { level: 'debug', extra: { participationId, nbAnswers: res.bulkSave.data.length, results: res.bulkSave.data }})
+          return res.bulkSave.data
+          
+        } catch (e) {
+          // If anything goes wrong, we catch it and log it
+          captureException(e, { extra: { participationId, sanitizeAnswers } })
+          return []
+        }
+      }),
+      map((results) => {
+        const bulked = results.reduce((acc, raw) => {
+          // Sanitize into correct payload form then push into related target
+          const qId = raw.attributes?.question?.data?.id
+          if (!qId) {
+            captureException(new Error('Bulk save : no question ID detected in resulting promise'), { extra: { rawAnswer: raw } })
+            return acc
+          }
+
+          if (!raw.id) {
+            captureException(new Error('Bulk save : no answer ID detected in resulting promise'), { extra: { rawAnswer: raw } })
+            return acc
+          }
+
+          const answer = { id: qId, changes: { id: raw.id } }
+          acc.push(answer)
+
+          return acc
+        }, [] as BulkSavedPayload)
+
+        return actions.bulkSaved(bulked)
+      })
+    )
+
+
+// Exports
+export const answersEpics = combineEpics(upsertAnswersEpic, bulkSaveAnswersEpic)

--- a/src/redux/slices/participation/answers.ts
+++ b/src/redux/slices/participation/answers.ts
@@ -29,6 +29,8 @@ export type UpsertedAnswerPayload = {
   updated: Update<AnswerParticipationRedux>[]
 }
 
+export type BulkSavedPayload = Update<AnswerParticipationRedux>[]
+
 // ---- SLICE
 
 const SLICE_NAME = "answers"
@@ -50,7 +52,13 @@ export const slice = createSlice({
     },
     clear: (state, action: PayloadAction<ClearAnswerPayload>) => {
       adapter.updateOne(state, { id: action.payload.questionId, changes: { value: null } })
-    }
+    },
+    bulkSave: (state) => {},
+    bulkSaved: (state, action: PayloadAction<BulkSavedPayload>) => {
+      // Update eveyrthing with the new IDs from the backend
+      adapter.updateMany(state, action.payload)
+    },
+
   },
   extraReducers: (builder) => {
     builder.addCase(statusAct.initialized, (state, action) => {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,3 +1,3 @@
-export function buildBearer(jwt: string | undefined | null) {
-  return jwt && jwt.length > 0 ? `Bearer ${jwt}` : "";
+export function buildBearer(token: string | undefined | null) {
+  return token && token.length > 0 ? `Bearer ${token}` : "";
 }


### PR DESCRIPTION
## What
This PR adds a `bulkSave` operation at the end of participation, which resaves all the answers again to ensure we have them all. This is a failsafe if things don't go well during the participation.

## How
At the end of the participation, it:
- triggers an action in Redux, which in turn triggers an epic
- it reads all the answers from the Redux, then sends them to the API (through the related `bulkSave` endpoint)
- waits for completion, catches relevant errors, logs the results of the API operation
- updates the Redux again with the results